### PR TITLE
Fix compilation error and some investigation about handle a non-tls client connection

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/MonitorGc.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/MonitorGc.java
@@ -53,7 +53,7 @@ public class MonitorGc implements Lifecycle
     @Override
     public void start() throws Throwable
     {
-        monitorGc = new MeasureDoNothing( "GC-Monitor", log, config.get( Configuration.gc_monitor_wait_time ),
+        monitorGc = new MeasureDoNothing( "neo4j.pauseMonitor", log, config.get( Configuration.gc_monitor_wait_time ),
                 config.get( Configuration.gc_monitor_threshold ) );
         monitorGc.start();
     }

--- a/community/ndp/kernelextension/pom.xml
+++ b/community/ndp/kernelextension/pom.xml
@@ -74,6 +74,13 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-ndp-transport-socket</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/community/ndp/kernelextension/src/main/java/org/neo4j/ext/NDPKernelExtension.java
+++ b/community/ndp/kernelextension/src/main/java/org/neo4j/ext/NDPKernelExtension.java
@@ -20,6 +20,9 @@
 package org.neo4j.ext;
 
 import io.netty.channel.Channel;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.function.Function;
@@ -112,6 +115,9 @@ public class NDPKernelExtension extends KernelExtensionFactory<NDPKernelExtensio
                     dependencies.scheduler(),
                     logging ) );
 
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            SslContext sslCtx = SslContextBuilder.forServer( ssc.certificate(), ssc.privateKey() ).build();
+
             PrimitiveLongObjectMap<Function<Channel, SocketProtocol>> availableVersions = longObjectMap();
             availableVersions.put( SocketProtocolV1.VERSION, new Function<Channel, SocketProtocol>()
             {
@@ -124,8 +130,8 @@ public class NDPKernelExtension extends KernelExtensionFactory<NDPKernelExtensio
 
             // Start services
             life.add( new NettyServer( asList(
-                    new SocketTransport( socketAddress, availableVersions ),
-                    new WebSocketTransport( webSocketAddress, availableVersions ) ) ) );
+                    new SocketTransport( socketAddress, sslCtx, availableVersions ),
+                    new WebSocketTransport( webSocketAddress, sslCtx, availableVersions ) ) ) );
             log.info( "NDP Server extension loaded." );
         }
 

--- a/community/ndp/kernelextension/src/test/java/org/neo4j/ext/NDPExtensionIT.java
+++ b/community/ndp/kernelextension/src/test/java/org/neo4j/ext/NDPExtensionIT.java
@@ -24,15 +24,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.ConnectException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.util.Arrays;
 
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.ndp.transport.socket.client.SocketConnection;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 public class NDPExtensionIT
@@ -68,7 +65,7 @@ public class NDPExtensionIT
         assertEventuallyServerResponds( "localhost", 8776 );
     }
 
-    private void assertEventuallyServerResponds( String host, int port ) throws IOException, InterruptedException
+    private void assertEventuallyServerResponds( String host, int port ) throws Exception
     {
         long timeout = System.currentTimeMillis() + 1000 * 30;
         for (; ; )
@@ -91,22 +88,18 @@ public class NDPExtensionIT
         }
     }
 
-    private boolean serverResponds( String host, int port ) throws IOException, InterruptedException
+    private boolean serverResponds( String host, int port ) throws Exception
     {
         try
         {
-            try ( Socket socket = new Socket() )
+            try ( SocketConnection conn = new SocketConnection() )
             {
                 // Ok, we can connect - can we perform the version handshake?
-                socket.connect( new InetSocketAddress( host, port ) );
-                OutputStream out = socket.getOutputStream();
-                InputStream in = socket.getInputStream();
+                conn.connect( new HostnamePort( host, port ) );
 
-                // Hard-coded handshake, a general "test client" would be useful further on.
-                out.write( new byte[]{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} );
+                conn.send( new byte[]{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} );
 
-                byte[] accepted = new byte[4];
-                in.read( accepted );
+                byte[] accepted = conn.recv( 4 );
 
                 return Arrays.equals( accepted, new byte[]{0, 0, 0, 1} );
             }

--- a/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketTransportHandler.java
+++ b/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketTransportHandler.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -79,6 +80,28 @@ public class SocketTransportHandler extends ChannelInboundHandlerAdapter
     public void handlerRemoved( ChannelHandlerContext ctx ) throws Exception
     {
         close();
+    }
+
+    @Override
+    public void userEventTriggered( ChannelHandlerContext ctx, Object evt ) throws Exception
+    {
+        if( evt instanceof SslHandshakeCompletionEvent )
+        {
+            if ( !((SslHandshakeCompletionEvent) evt).isSuccess() )
+            {
+                //handshake failed
+                //TODO downgrade to normal connection and send 0, 0, 0, 0 out
+//                ctx.writeAndFlush( wrappedBuffer( new byte[]{0, 0, 0, 0} ) )
+//                        .sync()
+//                        .channel()
+//                        .close();
+            }
+            // TODO another way to know the handshake result is
+//            ChannelPipeline p = ...;
+//            SslHandler sslHandler = p.get(SslHandler.class);
+//            sslHandler.handshakeFuture().addListener(new FutureListener<Channel> { ... });
+        }
+        ctx.fireUserEventTriggered( evt ); // TODO this will call ctx.close automatically
     }
 
     private void close()

--- a/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketTransportHandler.java
+++ b/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketTransportHandler.java
@@ -28,11 +28,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
-import org.neo4j.function.Factory;
 import org.neo4j.function.Function;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
-import static org.neo4j.collection.primitive.Primitive.longObjectMap;
 
 /**
  * Handles incoming chunks of data for a given client channel. This initially will negotiate a protocol version to use,

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/FragmentedMessageDeliveryTest.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/FragmentedMessageDeliveryTest.java
@@ -140,6 +140,10 @@ public class FragmentedMessageDeliveryTest
                                       "\n" +
                                       "Unfragmented data: " + HexPrinter.hex( unfragmented ) + "\n", e );
         }
+        finally
+        {
+            protocol.close(); // To avoid buffer leak errors
+        }
     }
 
     private String describeFragments( ByteBuf[] fragments )

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/client/NaiveTrustManager.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/client/NaiveTrustManager.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.transport.socket.client;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.X509TrustManager;
+
+/** Trust self-signed certificates */
+public class NaiveTrustManager implements X509TrustManager
+{
+    @Override
+    public void checkClientTrusted( X509Certificate[] x509Certificates, String s ) throws CertificateException
+    {
+
+    }
+
+    @Override
+    public void checkServerTrusted( X509Certificate[] x509Certificates, String s ) throws CertificateException
+    {
+
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers()
+    {
+        return null;
+    }
+}

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/client/SocketConnection.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/client/SocketConnection.java
@@ -24,10 +24,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
 
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.kernel.impl.util.HexPrinter;
 
 public class SocketConnection implements Connection
 {
@@ -36,9 +38,14 @@ public class SocketConnection implements Connection
     private OutputStream out;
 
     @Override
-    public Connection connect( HostnamePort address ) throws IOException
+    public Connection connect( HostnamePort address ) throws Exception
     {
-        socket = new Socket();
+        SSLContext context = SSLContext.getInstance( "SSL" );
+        context.init( new KeyManager[0], new TrustManager[] { new NaiveTrustManager() }, new SecureRandom( ) );
+
+        socket = context.getSocketFactory().createSocket();
+        socket.setSoTimeout( 30 * 1000 );
+
         socket.connect( new InetSocketAddress( address.getHost(), address.getPort() ) );
         in = socket.getInputStream();
         out = socket.getOutputStream();
@@ -55,19 +62,12 @@ public class SocketConnection implements Connection
     @Override
     public byte[] recv( int length ) throws IOException, InterruptedException
     {
-        long timeout = System.currentTimeMillis() + 1000 * 30;
         byte[] bytes = new byte[length];
         int left = length, read;
-
-        waitUntilAvailable( bytes, timeout, left );
 
         while ( (read = in.read( bytes, length - left, left )) != -1 && left > 0 )
         {
             left -= read;
-            if ( left > 0 )
-            {
-                waitUntilAvailable( bytes, timeout, left );
-            }
         }
         return bytes;
     }
@@ -78,20 +78,6 @@ public class SocketConnection implements Connection
         for ( int i = 0; i < length; i++ )
         {
             in.read();
-        }
-    }
-
-    private void waitUntilAvailable( byte[] recieved, long timeout, int left ) throws IOException
-    {
-        while ( in.available() == 0 )
-        {
-            if ( System.currentTimeMillis() > timeout )
-            {
-                throw new IOException( "Waited 30 seconds for " + left + " bytes, " +
-                                       "recieved " + (recieved.length - left) + ":\n" +
-                                       HexPrinter.hex(
-                                               ByteBuffer.wrap( recieved ), 0, recieved.length - left ) );
-            }
         }
     }
 

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/client/WebSocketConnection.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/client/WebSocketConnection.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.ndp.transport.socket.client;
 
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.api.RemoteEndpoint;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketListener;
@@ -36,7 +37,6 @@ import org.neo4j.kernel.impl.util.HexPrinter;
 
 public class WebSocketConnection implements Connection, WebSocketListener
 {
-    private Session session;
     private WebSocketClient client;
     private RemoteEndpoint server;
 
@@ -52,11 +52,12 @@ public class WebSocketConnection implements Connection, WebSocketListener
     @Override
     public Connection connect( HostnamePort address ) throws Exception
     {
-        URI target = URI.create( "ws://" + address.getHost() + ":" + address.getPort() );
+        URI target = URI.create( "wss://" + address.getHost() + ":" + address.getPort() );
 
-        client = new WebSocketClient();
+        client = new WebSocketClient( new SslContextFactory( /* trustall= */ true ) );
         client.start();
-        session = client.connect( this, target ).get( 30, TimeUnit.SECONDS );
+
+        Session session = client.connect( this, target ).get( 30, TimeUnit.SECONDS );
         server = session.getRemote();
         return this;
     }

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/Neo4jWithSocket.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/Neo4jWithSocket.java
@@ -20,6 +20,9 @@
 package org.neo4j.ndp.transport.socket.integration;
 
 import io.netty.channel.Channel;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -80,9 +83,13 @@ public class Neo4jWithSocket implements TestRule
                     }
                 } );
 
+                SelfSignedCertificate ssc = new SelfSignedCertificate();
+                SslContext sslCtx = SslContextBuilder.forServer( ssc.certificate(), ssc.privateKey() ).build();
+
                 // Start services
-                socketTransport = new SocketTransport( new HostnamePort( "localhost:7687" ), availableVersions );
-                wsTransport = new WebSocketTransport( new HostnamePort( "localhost:7688" ), availableVersions );
+                socketTransport = new SocketTransport( new HostnamePort( "localhost:7687" ), sslCtx,
+                        availableVersions );
+                wsTransport = new WebSocketTransport( new HostnamePort( "localhost:7688" ), sslCtx, availableVersions );
                 life.add( new NettyServer( asList(
                         socketTransport,
                         wsTransport )) );

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
@@ -48,6 +48,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.harness.extensionpackage.MyUnmanagedExtension;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.server.configuration.Configurator;
+import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.Mute;
 import org.neo4j.test.TargetDirectory;
@@ -99,9 +100,9 @@ public class InProcessBuilderTest
         // When
         try ( ServerControls server = newInProcessBuilder( testDir.directory() )
                 .withConfig( Configurator.WEBSERVER_HTTPS_ENABLED_PROPERTY_KEY, "true")
-                .withConfig( Configurator.WEBSERVER_HTTPS_CERT_PATH_PROPERTY_KEY, testDir.file( "cert" ).getAbsolutePath() )
+                .withConfig( ServerSettings.tls_certificate_file.name(), testDir.file( "cert" ).getAbsolutePath() )
                 .withConfig( Configurator.WEBSERVER_KEYSTORE_PATH_PROPERTY_KEY, testDir.file( "keystore" ).getAbsolutePath() )
-                .withConfig( Configurator.WEBSERVER_HTTPS_KEY_PATH_PROPERTY_KEY, testDir.file( "key" ).getAbsolutePath() )
+                .withConfig( ServerSettings.tls_key_file.name(), testDir.file( "key" ).getAbsolutePath() )
                 .withConfig( GraphDatabaseSettings.dense_node_threshold, "20" )
                 .newServer() )
         {

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -392,7 +392,7 @@ public abstract class AbstractNeoServer implements NeoServer
     // TODO: Once WebServer is fully implementing LifeCycle,
     // it should manage all but static (eg. unchangeable during runtime)
     // configuration itself.
-    private void configureWebServer()
+    private void configureWebServer() throws Exception
     {
         int webServerPort = getWebServerPort();
         String webServerAddr = getWebServerAddress();
@@ -530,13 +530,13 @@ public abstract class AbstractNeoServer implements NeoServer
      * permissions etc), like you do with Apache Web Server. On each startup
      * we set up a key store for them with their certificate in it.
      */
-    protected KeyStoreInformation initHttpsKeyStore()
+    protected KeyStoreInformation initHttpsKeyStore() throws Exception
     {
         File keystorePath = configurator.configuration().get( ServerSettings.webserver_keystore_path );
 
-        File privateKeyPath = configurator.configuration().get( ServerSettings.webserver_https_key_path );
+        File privateKeyPath = configurator.configuration().get( ServerSettings.tls_key_file );
 
-        File certificatePath = configurator.configuration().get( ServerSettings.webserver_https_cert_path );
+        File certificatePath = configurator.configuration().get( ServerSettings.tls_certificate_file );
 
         if ( !certificatePath.exists() )
         {

--- a/community/server/src/main/java/org/neo4j/server/configuration/Configurator.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/Configurator.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.server.configuration;
 
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,14 +29,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
-
 import org.neo4j.helpers.TimeUtil;
 import org.neo4j.kernel.info.DiagnosticsExtractor;
 import org.neo4j.kernel.info.DiagnosticsPhase;
 import org.neo4j.logging.Logger;
 import org.neo4j.server.web.ServerInternalSettings;
+
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
@@ -97,11 +98,11 @@ public interface Configurator
     String WEBSERVER_KEYSTORE_PATH_PROPERTY_KEY = ServerSettings.webserver_keystore_path.name();
     String DEFAULT_WEBSERVER_KEYSTORE_PATH = ServerSettings.webserver_keystore_path.getDefaultValue();
 
-    String WEBSERVER_HTTPS_CERT_PATH_PROPERTY_KEY = ServerSettings.webserver_https_cert_path.name();
-    String DEFAULT_WEBSERVER_HTTPS_CERT_PATH = ServerSettings.webserver_https_cert_path.getDefaultValue();
+    String WEBSERVER_HTTPS_CERT_PATH_PROPERTY_KEY = ServerSettings.tls_certificate_file.name();
+    String DEFAULT_WEBSERVER_HTTPS_CERT_PATH = ServerSettings.tls_certificate_file.getDefaultValue();
 
-    String WEBSERVER_HTTPS_KEY_PATH_PROPERTY_KEY = ServerSettings.webserver_https_key_path.name();
-    String DEFAULT_WEBSERVER_HTTPS_KEY_PATH = ServerSettings.webserver_https_key_path.getDefaultValue();
+    String WEBSERVER_HTTPS_KEY_PATH_PROPERTY_KEY = ServerSettings.tls_key_file.name();
+    String DEFAULT_WEBSERVER_HTTPS_KEY_PATH = ServerSettings.tls_key_file.getDefaultValue();
 
     String HTTP_LOGGING = ServerSettings.http_logging_enabled.name();
     boolean DEFAULT_HTTP_LOGGING = Boolean.valueOf( ServerSettings.http_logging_enabled.getDefaultValue() );

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerConfigurationMigrator.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerConfigurationMigrator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.configuration;
+
+import org.neo4j.kernel.configuration.BaseConfigurationMigrator;
+
+public class ServerConfigurationMigrator extends BaseConfigurationMigrator
+{
+    {
+        add( new PropertyRenamed(
+                "org.neo4j.server.webserver.https.cert.location",
+                "dbms.security.tls_certificate_file",
+                "The TLS certificate configuration you are using, 'org.neo4j.server.webserver.https.cert.location' is " +
+                "deprecated. Please use 'dbms.security.tls_certificate_file' instead."
+        ));
+        add( new PropertyRenamed(
+                "org.neo4j.server.webserver.https.key.location",
+                "dbms.security.tls_key_file",
+                "The TLS key configuration you are using, " +
+                "'org.neo4j.server.webserver.https.key.location' is deprecated, please use " +
+                "'dbms.security.tls_key_file' instead."
+        ));
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -28,7 +28,9 @@ import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.ConfigurationMigrator;
 import org.neo4j.kernel.configuration.Internal;
+import org.neo4j.kernel.configuration.Migrator;
 
 import static org.neo4j.helpers.Settings.ANY;
 import static org.neo4j.helpers.Settings.BOOLEAN;
@@ -51,6 +53,8 @@ import static org.neo4j.helpers.Settings.setting;
 @Description("Settings used by the server configuration")
 public interface ServerSettings
 {
+    @Migrator
+    ConfigurationMigrator migrator = new ServerConfigurationMigrator();
 
     @Description( "Maximum request header size" )
     Setting<Integer> maximum_request_header_size =
@@ -139,13 +143,26 @@ public interface ServerSettings
     Setting<File> webserver_keystore_path = setting(
             "org.neo4j.server.webserver.https.keystore.location", PATH, "neo4j-home/ssl/keystore" );
 
-    @Description( "Path to the SSL certificate used for HTTPS connections." )
+    @Description( "Path to the X.509 public certificate to be used by Neo4j for TLS connections" )
+    Setting<File> tls_certificate_file = setting(
+            "dbms.security.tls_certificate_file", PATH, "neo4j-home/ssl/snakeoil.cert" );
+
+    @Description( "Path to the X.509 private key to be used by Neo4j for TLS connections" )
+    Setting<File> tls_key_file = setting(
+            "dbms.security.tls_key_file", PATH, "neo4j-home/ssl/snakeoil.key" );
+
+    @Deprecated
+    @Description( "Path to the SSL certificate used for HTTPS connections. This is deprecated, please use " +
+                  "'dbms.security.tls_certificate_file' instead." )
     Setting<File> webserver_https_cert_path = setting(
             "org.neo4j.server.webserver.https.cert.location", PATH, "neo4j-home/ssl/snakeoil.cert" );
 
-    @Description( "Path to the SSL key used for HTTPS connections." )
+    @Deprecated
+    @Description( "Path to the SSL key used for HTTPS connections. This is deprecated, please use " +
+                  "'dbms.security.tls_key_file'" )
     Setting<File> webserver_https_key_path = setting(
             "org.neo4j.server.webserver.https.key.location", PATH, "neo4j-home/ssl/snakeoil.key" );
+
 
     @Description( "Enable HTTP request logging." )
     Setting<Boolean> http_logging_enabled = setting( "org.neo4j.server.http.log.enabled", BOOLEAN, FALSE );

--- a/community/server/src/main/java/org/neo4j/server/modules/NDPModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/NDPModule.java
@@ -20,7 +20,12 @@
 package org.neo4j.server.modules;
 
 import io.netty.channel.Channel;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.io.File;
+import javax.net.ssl.SSLException;
 
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.function.Function;
@@ -65,47 +70,58 @@ public class NDPModule implements ServerModule
     @Override
     public void start()
     {
-        // These three pulled out dynamically due to initialization ordering issue where this module is
-        // created before the below services are created. A bigger piece of work is pending to
-        // organize this module life cycle better.
-        final GraphDatabaseAPI api = dependencyResolver.resolveDependency( GraphDatabaseAPI.class );
-        final LogService logging = dependencyResolver.resolveDependency( LogService.class );
-        final UsageData usageData = dependencyResolver.resolveDependency( UsageData.class );
-        final JobScheduler scheduler = dependencyResolver.resolveDependency( JobScheduler.class );
-
-        final Log internalLog = logging.getInternalLog( Sessions.class );
-        final Log userLog = logging.getUserLog( Sessions.class );
-
-        final HostnamePort socketAddress = config.get( ServerSettings.ndp_socket_address );
-        final HostnamePort webSocketAddress = config.get( ServerSettings.ndp_ws_address );
-
-        if ( config.get( ServerSettings.ndp_enabled ) )
+        try
         {
-            final Sessions sessions = life.add( new ThreadedSessions(
-                    life.add( new StandardSessions( api, usageData, logging ) ),
-                    scheduler,
-                    logging ) );
+            // These three pulled out dynamically due to initialization ordering issue where this module is
+            // created before the below services are created. A bigger piece of work is pending to
+            // organize this module life cycle better.
+            final GraphDatabaseAPI api = dependencyResolver.resolveDependency( GraphDatabaseAPI.class );
+            final LogService logging = dependencyResolver.resolveDependency( LogService.class );
+            final UsageData usageData = dependencyResolver.resolveDependency( UsageData.class );
+            final JobScheduler scheduler = dependencyResolver.resolveDependency( JobScheduler.class );
 
-            PrimitiveLongObjectMap<Function<Channel,SocketProtocol>> availableVersions = longObjectMap();
-            availableVersions.put( SocketProtocolV1.VERSION, new Function<Channel,SocketProtocol>()
+            final Log internalLog = logging.getInternalLog( Sessions.class );
+            final Log userLog = logging.getUserLog( Sessions.class );
+
+            final File certificateFile = config.get( ServerSettings.tls_certificate_file );
+            final File keyFile = config.get( ServerSettings.tls_key_file );
+            final HostnamePort socketAddress = config.get( ServerSettings.ndp_socket_address );
+            final HostnamePort webSocketAddress = config.get( ServerSettings.ndp_ws_address );
+
+            if ( config.get( ServerSettings.ndp_enabled ) )
             {
-                @Override
-                public SocketProtocol apply( Channel channel )
+                final Sessions sessions = life.add( new ThreadedSessions(
+                        life.add( new StandardSessions( api, usageData, logging ) ),
+                        scheduler,
+                        logging ) );
+
+                PrimitiveLongObjectMap<Function<Channel,SocketProtocol>> availableVersions = longObjectMap();
+                availableVersions.put( SocketProtocolV1.VERSION, new Function<Channel,SocketProtocol>()
                 {
-                    return new SocketProtocolV1( logging, sessions.newSession(), channel );
-                }
-            } );
+                    @Override
+                    public SocketProtocol apply( Channel channel )
+                    {
+                        return new SocketProtocolV1( logging, sessions.newSession(), channel );
+                    }
+                } );
 
-            InternalLoggerFactory.setDefaultFactory( new Netty4LoggerFactory( logging.getInternalLogProvider() ) );
-            life.add( new NettyServer( asList(
-                    new SocketTransport( socketAddress, availableVersions ),
-                    new WebSocketTransport( webSocketAddress, availableVersions ) ) ) );
-            internalLog.info( "NDP Server extension loaded." );
-            userLog.info( "Experimental NDP support enabled! Listening for socket connections on " + socketAddress +
-                          " and for websocket connections on " + webSocketAddress + ".");
+                SslContext sslCtx = SslContextBuilder.forServer( certificateFile, keyFile ).build();
+
+                InternalLoggerFactory.setDefaultFactory( new Netty4LoggerFactory( logging.getInternalLogProvider() ) );
+                life.add( new NettyServer( asList(
+                        new SocketTransport( socketAddress, sslCtx, availableVersions ),
+                        new WebSocketTransport( webSocketAddress, sslCtx, availableVersions ) ) ) );
+                internalLog.info( "NDP Server extension loaded." );
+                userLog.info( "Experimental NDP support enabled! Listening for socket connections on " + socketAddress +
+                              " and for websocket connections on " + webSocketAddress + "." );
+            }
+
+            life.start();
         }
-
-        life.start();
+        catch( SSLException e )
+        {
+            throw new RuntimeException( "Failed to configure TLS during NDP startup: " + e.getMessage(), e );
+        }
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/SslCertificateFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/SslCertificateFactory.java
@@ -19,10 +19,13 @@
  */
 package org.neo4j.server.security.ssl;
 
+import org.bouncycastle.jce.X509Principal;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.x509.X509V3CertificateGenerator;
+
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -32,10 +35,13 @@ import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.SignatureException;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.spec.InvalidKeySpecException;
@@ -43,12 +49,7 @@ import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Collection;
 import java.util.Date;
-
 import javax.crypto.NoSuchPaddingException;
-
-import org.bouncycastle.jce.X509Principal;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.x509.X509V3CertificateGenerator;
 
 public class SslCertificateFactory {
 
@@ -58,78 +59,46 @@ public class SslCertificateFactory {
     {
         Security.addProvider(new BouncyCastleProvider());
     }
-    
-    public void createSelfSignedCertificate(File certificatePath,
-            File privateKeyPath, String hostName)
+
+    public void createSelfSignedCertificate(File certificatePath, File privateKeyPath, String hostName)
+            throws NoSuchAlgorithmException, CertificateEncodingException, NoSuchProviderException, InvalidKeyException,
+            SignatureException, IOException
     {
-        FileOutputStream fos = null;
-        try {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( KEY_ENCRYPTION );
+        keyPairGenerator.initialize(1024);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
 
-            KeyPairGenerator keyPairGenerator = KeyPairGenerator
-                    .getInstance(KEY_ENCRYPTION);
-            keyPairGenerator.initialize(1024);
-            KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        X509V3CertificateGenerator certGen = new X509V3CertificateGenerator();
 
-            X509V3CertificateGenerator certGenertor = new X509V3CertificateGenerator();
+        certGen.setSerialNumber( BigInteger.valueOf( new SecureRandom().nextInt() ).abs() );
+        certGen.setIssuerDN( new X509Principal( "CN=" + hostName + ", OU=None, O=None L=None, C=None" ) );
+        certGen.setNotBefore( new Date( System.currentTimeMillis() - 1000L * 60 * 60 * 24 * 30 ) );
+        certGen.setNotAfter( new Date( System.currentTimeMillis() + (1000L * 60 * 60 * 24 * 365 * 10) ) );
+        certGen.setSubjectDN( new X509Principal( "CN=" + hostName + ", OU=None, O=None L=None, C=None" ) );
 
-            certGenertor.setSerialNumber(BigInteger.valueOf(
-                    new SecureRandom().nextInt()).abs());
-            certGenertor.setIssuerDN(new X509Principal("CN=" + hostName
-                    + ", OU=None, O=None L=None, C=None"));
-            certGenertor.setNotBefore(new Date(System.currentTimeMillis()
-                    - 1000L * 60 * 60 * 24 * 30));
-            certGenertor.setNotAfter(new Date(System.currentTimeMillis()
-                    + (1000L * 60 * 60 * 24 * 365 * 10)));
-            certGenertor.setSubjectDN(new X509Principal("CN=" + hostName
-                    + ", OU=None, O=None L=None, C=None"));
+        certGen.setPublicKey( keyPair.getPublic() );
+        certGen.setSignatureAlgorithm( "MD5WithRSAEncryption" );
 
-            certGenertor.setPublicKey(keyPair.getPublic());
-            certGenertor.setSignatureAlgorithm("MD5WithRSAEncryption");
+        Certificate certificate = certGen.generate( keyPair.getPrivate(), "BC");
 
-            Certificate certificate = certGenertor.generate(
-                    keyPair.getPrivate(), "BC");            
+        ensureFolderExists(certificatePath.getParentFile());
+        ensureFolderExists(privateKeyPath.getParentFile());
 
-            ensureFolderExists(certificatePath.getParentFile());
-            ensureFolderExists(privateKeyPath.getParentFile());
-            
-            fos = new FileOutputStream(certificatePath);
-            fos.write(certificate.getEncoded());
-            fos.close();
-
-            fos = new FileOutputStream(privateKeyPath);
-            fos.write(keyPair.getPrivate().getEncoded());
-            fos.close();
-
-        } catch (Exception e)
+        try(FileOutputStream certStream = new FileOutputStream(certificatePath);
+            FileOutputStream keyStream = new FileOutputStream( privateKeyPath ))
         {
-            throw new RuntimeException("Unable to create self signed SSL certificate, please see nested exception.", e);
-        } finally {
-            if (fos != null) {
-                try {
-                    fos.close();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
+            certStream.write( certificate.getEncoded() );
+            keyStream.write( keyPair.getPrivate().getEncoded() );
         }
     }
 
-    public Certificate[] loadCertificates(File certFile)
-            throws CertificateException, FileNotFoundException {
-        FileInputStream fis = null;
-        try {
-            fis = new FileInputStream(certFile);
-            Collection<? extends Certificate> certificates = CertificateFactory.getInstance(CERTIFICATE_TYPE).generateCertificates(
-                    fis);
-            return certificates.toArray(new Certificate[]{});
-        } finally {
-            if (fis != null) {
-                try {
-                    fis.close();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
+    public Certificate[] loadCertificates(File certFile) throws CertificateException, IOException
+    {
+        try(FileInputStream in = new FileInputStream(certFile))
+        {
+            CertificateFactory factory = CertificateFactory.getInstance( CERTIFICATE_TYPE );
+            Collection<? extends Certificate> certificates = factory.generateCertificates( in );
+            return certificates.toArray(new Certificate[certificates.size()]);
         }
     }
 
@@ -137,35 +106,22 @@ public class SslCertificateFactory {
             throws IOException, NoSuchAlgorithmException,
             InvalidKeySpecException, NoSuchPaddingException,
             InvalidKeyException, InvalidAlgorithmParameterException 
-            {
-        DataInputStream dis = null;
-        try 
+    {
+        try(DataInputStream in = new DataInputStream(new FileInputStream(privateKeyFile)))
         {
-            FileInputStream fis = new FileInputStream(privateKeyFile);
-            dis = new DataInputStream(fis);
             byte[] keyBytes = new byte[(int) privateKeyFile.length()];
-            dis.readFully(keyBytes);
+            in.readFully( keyBytes );
 
             KeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
 
             return KeyFactory.getInstance(KEY_ENCRYPTION).generatePrivate(keySpec);
-        } catch (FileNotFoundException e ) 
-        {
-            throw new IOException("Could not find private key file to use for SSL support, see nested exception.", e);
-        } finally 
-        {
-            if (dis != null) {
-                try {
-                    dis.close();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
         }
     }
 
-    private void ensureFolderExists(File path) {
-        if(!path.exists()) {
+    private void ensureFolderExists(File path)
+    {
+        if(!path.exists())
+        {
             path.mkdirs();
         }
     }

--- a/community/server/src/test/java/org/neo4j/server/Neo4jDataProtocolIT.java
+++ b/community/server/src/test/java/org/neo4j/server/Neo4jDataProtocolIT.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.server;
 
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -27,14 +29,24 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.Arrays;
+import java.net.SocketTimeoutException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.neo4j.server.helpers.CommunityServerBuilder.server;
 
 public class Neo4jDataProtocolIT extends ExclusiveServerTestBase
@@ -43,6 +55,13 @@ public class Neo4jDataProtocolIT extends ExclusiveServerTestBase
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
     private CommunityNeoServer server;
+    private static SelfSignedCertificate ssc;
+
+    @BeforeClass
+    public static void setup() throws CertificateException
+    {
+        ssc = new SelfSignedCertificate();
+    }
 
     @After
     public void stopTheServer()
@@ -55,6 +74,8 @@ public class Neo4jDataProtocolIT extends ExclusiveServerTestBase
     {
         // When I run Neo4j with NDP enabled
         server = server()
+                .withProperty( ServerSettings.tls_key_file.name(), ssc.privateKey().getAbsolutePath() )
+                .withProperty( ServerSettings.tls_certificate_file.name(), ssc.certificate().getAbsolutePath() )
                 .withProperty( ServerSettings.ndp_enabled.name(), "true" )
                 .usingDatabaseDir( tmpDir.getRoot().getAbsolutePath() )
                 .build();
@@ -70,6 +91,8 @@ public class Neo4jDataProtocolIT extends ExclusiveServerTestBase
         // When I run Neo4j with the ndp extension on the class path
         // When I run Neo4j with NDP enabled
         server = server()
+                .withProperty( ServerSettings.tls_key_file.name(), ssc.privateKey().getAbsolutePath() )
+                .withProperty( ServerSettings.tls_certificate_file.name(), ssc.certificate().getAbsolutePath() )
                 .withProperty( ServerSettings.ndp_enabled.name(), "true" )
                 .withProperty( ServerSettings.ndp_socket_address.name(), "localhost:8776" )
                 .usingDatabaseDir( tmpDir.getRoot().getAbsolutePath() )
@@ -80,36 +103,70 @@ public class Neo4jDataProtocolIT extends ExclusiveServerTestBase
         assertEventuallyServerResponds( "localhost", 8776 );
     }
 
-    private void assertEventuallyServerResponds( String host, int port ) throws IOException, InterruptedException
+    @Test
+    public void shouldFailSslHandshake() throws Throwable
     {
-        long timeout = System.currentTimeMillis() + 1000 * 30;
-        for (; ; )
-        {
-            if ( serverResponds( host, port ) )
-            {
-                return;
-            }
-            else
-            {
-                Thread.sleep( 100 );
-            }
+        // When I create a server and waiting for connection
+        server = server()
+                .withProperty( ServerSettings.tls_key_file.name(), ssc.privateKey().getAbsolutePath() )
+                .withProperty( ServerSettings.tls_certificate_file.name(), ssc.certificate().getAbsolutePath() )
+                .withProperty( ServerSettings.ndp_enabled.name(), "true" )
+                .withProperty( ServerSettings.ndp_socket_address.name(), "localhost:8776" )
+                .usingDatabaseDir( tmpDir.getRoot().getAbsolutePath() )
+                .build();
+        server.start();
 
-            // Make sure process still is alive
-            if ( System.currentTimeMillis() > timeout )
-            {
-                throw new RuntimeException( "Waited for 30 seconds for server to respond to HTTP calls, " +
-                                            "but no response, timing out to avoid blocking forever." );
-            }
+        // Then
+        try( Socket socket = new Socket() )
+        {
+            socket.setSoTimeout( 30_000 );
+            socket.connect( new InetSocketAddress( "localhost", 8776 ) );
+            OutputStream out = socket.getOutputStream();
+            InputStream in = socket.getInputStream();
+
+            // some random data to fail ssl handshake
+            out.write( new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 14, 15} );
+
+            byte[] accepted = {-1, -1, -1, -1}; // some value except 0, 0, 0, 0
+            int read = in.read( accepted );
+
+            assertEquals( 4, read );
+            assertArrayEquals( new byte[]{0, 0, 0, 0}, accepted );
         }
+
     }
 
-    private boolean serverResponds( String host, int port ) throws IOException, InterruptedException
+    private void assertEventuallyServerResponds( String host, int port )
+            throws IOException, NoSuchAlgorithmException, KeyManagementException
     {
         try
         {
-            try ( Socket socket = new Socket() )
+            SSLContext context = SSLContext.getInstance( "SSL" );
+            context.init( new KeyManager[0], new TrustManager[]{new X509TrustManager()
+            {
+                @Override
+                public void checkClientTrusted( X509Certificate[] x509Certificates, String s )
+                        throws CertificateException
+                {
+                }
+
+                @Override
+                public void checkServerTrusted( X509Certificate[] x509Certificates, String s )
+                        throws CertificateException
+                {
+                }
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers()
+                {
+                    return null;
+                }
+            }}, new SecureRandom() );
+
+            try ( Socket socket = context.getSocketFactory().createSocket(); )
             {
                 // Ok, we can connect - can we perform the version handshake?
+                socket.setSoTimeout( 30_000 );
                 socket.connect( new InetSocketAddress( host, port ) );
                 OutputStream out = socket.getOutputStream();
                 InputStream in = socket.getInputStream();
@@ -120,12 +177,13 @@ public class Neo4jDataProtocolIT extends ExclusiveServerTestBase
                 byte[] accepted = new byte[4];
                 in.read( accepted );
 
-                return Arrays.equals( accepted, new byte[]{0, 0, 0, 1} );
+                assertArrayEquals( new byte[]{0, 0, 0, 1}, accepted );
             }
         }
-        catch ( ConnectException e )
+        catch ( SocketTimeoutException e )
         {
-            return false;
+            throw new RuntimeException( "Waited for 30 seconds for server to respond to HTTP calls, " +
+                                        "but no response, timing out to avoid blocking forever." );
         }
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.configuration;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.AssertableLogProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.server.configuration.ServerSettings.webserver_https_cert_path;
+import static org.neo4j.server.configuration.ServerSettings.webserver_https_key_path;
+
+public class ServerSettingsTest
+{
+    @Test
+    public void shouldConvertWebserverTLSToDBMSTLS() throws Throwable
+    {
+        // Given
+        final AssertableLogProvider logging = new AssertableLogProvider();
+
+        // When
+        final Config config = new Config( stringMap(
+                webserver_https_cert_path.name(), "whatever/cert",
+                webserver_https_key_path.name(), "whatever/key" ), ServerSettings.class );
+        config.setLogger( logging.getLog( "config" ) );
+
+        // Then
+        assertEquals( "whatever/cert", config.get( ServerSettings.tls_certificate_file ).getPath() );
+        assertEquals( "whatever/key", config.get( ServerSettings.tls_key_file ).getPath() );
+        logging.assertContainsMessageContaining(
+                "The TLS certificate configuration you are using, 'org.neo4j.server.webserver.https.cert.location' " +
+                "is deprecated. Please use 'dbms.security.tls_certificate_file' instead." );
+        logging.assertContainsMessageContaining(
+                "The TLS key configuration you are using, 'org.neo4j.server.webserver.https.key.location' " +
+                "is deprecated, please use 'dbms.security.tls_key_file' instead." );
+    }
+
+}


### PR DESCRIPTION
Problem left: how to send 00 00 00 00 to a non-tls client
The server would not send anything to the client until ssl handshake success. However once the first ssl handshake fails, the server will close the connection by default.
So the client would merely get a end_of file reading error.

Possible solution:
Instead of using netty to handle handshake, we maintain the handshake cycle and downgrade to normal socket connection if handshake fails
